### PR TITLE
Change from ::set-env to $GITHUB_ENV

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ main(){
 	repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
 
 
-	echo ::set-env name=BRANCH_NAME::${ref}
+	echo "BRANCH_NAME=${ref}" >> $GITHUB_ENV
 
 	exit 0
 }


### PR DESCRIPTION
As discussed [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), `::set-env` is being deprecated because of a vulnerability, so this switches to using `$GITHUB_ENV`. This fixes deprecation warnings like the one seen [here](https://github.com/winnipegpolicecauseharm/wpch-ghost-theme/actions/runs/358404385), with the fork it’s gone [here](https://github.com/winnipegpolicecauseharm/wpch-ghost-theme/actions/runs/358442782). (The workflow failure is unrelated.) The deprecation warning says `::set-env` will go away in less than a week! 😳

Thanks for this action, it’s helpful to streamline determining a PR’s branch so I can construct relevant Heroku application names for deployment previews. 🎉